### PR TITLE
BUGFIX: Match ternary expressions with simple variables.

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -640,7 +640,7 @@ repository:
         '1': {name: punctuation.separator.key-value.js}
 
     - name: constant.other.object.key.js
-      match: (?<!\.)([_$a-zA-Z][_$\w]*)\s*(:)
+      match: (?<!\.|\?|\? )([_$a-zA-Z][_$\w]*)\s*(:)
       captures:
         '1': {name: string.unquoted.label.js}
         '2': {name: punctuation.separator.key-value.js}

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1372,7 +1372,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)([_$a-zA-Z][_$\w]*)\s*(:)</string>
+					<string>(?&lt;!\.|\?|\? )([_$a-zA-Z][_$\w]*)\s*(:)</string>
 					<key>name</key>
 					<string>constant.other.object.key.js</string>
 				</dict>


### PR DESCRIPTION
Commit #da5a552 fixed Issue #50 but broke ternary expressions match for simple variables like this:
    
    var hola = var1 ? var1 : var2;

![test](https://cloud.githubusercontent.com/assets/10518807/5784780/cbac0296-9d9d-11e4-9273-6948b001abf0.png)