### PR TITLE
Capture "prototype" as "variable.language.prototype"

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -223,14 +223,14 @@ repository:
       match: ([_$a-zA-Z][_$\w]*)\.(prototype)\s*=\s*
       captures:
         '1': {name: entity.name.class.js}
-        '2': {name: support.constant.js}
+        '2': {name: variable.language.prototype.js}
 
     # e.g. Sound.prototype
     - name: meta.prototype.js
       match: ([_$a-zA-Z][_$\w]*)\.(prototype)
       captures:
         '1': {name: entity.name.class.js}
-        '2': {name: support.constant.js}
+        '2': {name: variable.language.prototype.js}
 
   literal-function-storage:
     patterns:
@@ -258,7 +258,7 @@ repository:
           \s*(function(?:\s*\*|(?=\s|[(])))\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
-        '2': {name: support.constant.js}
+        '2': {name: variable.language.prototype.js}
         '3': {name: entity.name.function.js}
         '4': {name: storage.type.function.js}
       end: (?<=\))
@@ -345,7 +345,7 @@ repository:
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
-        '2': {name: support.constant.js}
+        '2': {name: variable.language.prototype.js}
         '3': {name: entity.name.function.js}
       end: (?<=\))\s*(=>)
       endCaptures:

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -530,7 +530,7 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.js</string>
+							<string>variable.language.prototype.js</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -947,7 +947,7 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.js</string>
+							<string>variable.language.prototype.js</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -1629,7 +1629,7 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.js</string>
+							<string>variable.language.prototype.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
@@ -1648,7 +1648,7 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>support.constant.js</string>
+							<string>variable.language.prototype.js</string>
 						</dict>
 					</dict>
 					<key>match</key>

--- a/Monokai Phoenix.YAML-tmTheme
+++ b/Monokai Phoenix.YAML-tmTheme
@@ -187,7 +187,7 @@ settings:
     foreground: '#66D9EF'
 
 - name: Library class/type
-  scope: support.type, support.class
+  scope: support.type, support.class, variable.language
   settings:
     fontStyle: italic
     foreground: '#66D9EF'

--- a/Monokai Phoenix.tmTheme
+++ b/Monokai Phoenix.tmTheme
@@ -408,7 +408,7 @@
 			<key>name</key>
 			<string>Library class/type</string>
 			<key>scope</key>
-			<string>support.type, support.class</string>
+			<string>support.type, support.class, variable.language</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>


### PR DESCRIPTION
`prototype` is matched in the `literal-language-variable` group as [`variable.language.prototype`](https://github.com/Benvie/JavaScriptNext.tmLanguage/blob/9eb740661bdf1a50e1292fcb7416cc55666a3ce7/JavaScriptNext.YAML-tmLanguage#L498), and probably should be matched the same in "literate storage" groups.

Also, this adjusts Monokai, so all `variable.language` are under "Library class/type". The effect in Monokai is that before, `prototype` when matched in the "literate storage" groups, would get `#66D9EF`, but now it'll get italic too - along with `this`, `__proto__`, `arguments`, `super`, `self` and `constructor`