### PR TITLE
"module" was removed from the Modules spec

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -153,10 +153,6 @@ repository:
 
   literal-module:
     patterns:
-    # module names are defined using strings
-    - name: storage.type.module.js
-      match: (?<!\.)\b(module)\b
-
     - name: keyword.operator.module.js
       match: (?<!\.)\b(import|export|from|as)\b
 
@@ -866,7 +862,7 @@ repository:
       match: (?<!\.)\b(natives|buffer|child_process|cluster|crypto|dgram|dns|fs|http|https|net|os|path|punycode|string|string_decoder|readline|repl|tls|tty|util|vm|zlib)\b
 
     - name: support.type.object.node.js
-      match: (?<!\.)\b(process|process\.(env|stdout|stdin|stderr)|global|GLOBAL|root|exports|__dirname|__filename|console)\b
+      match: (?<!\.)\b(process|process\.(env|stdout|stdin|stderr)|global|GLOBAL|root|module|exports|__dirname|__filename|console)\b
 
     - name: support.class.node.js
       match: \b(Buffer|EventEmitter|Server|Pipe|Socket|REPLServer|ReadStream|WriteStream|Stream|Inflate|Deflate|InflateRaw|DeflateRaw|GZip|GUnzip|Unzip|Zip)\b

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1564,12 +1564,6 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(module)\b</string>
-					<key>name</key>
-					<string>storage.type.module.js</string>
-				</dict>
-				<dict>
-					<key>match</key>
 					<string>(?&lt;!\.)\b(import|export|from|as)\b</string>
 					<key>name</key>
 					<string>keyword.operator.module.js</string>
@@ -2120,7 +2114,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(process|process\.(env|stdout|stdin|stderr)|global|GLOBAL|root|exports|__dirname|__filename|console)\b</string>
+					<string>(?&lt;!\.)\b(process|process\.(env|stdout|stdin|stderr)|global|GLOBAL|root|module|exports|__dirname|__filename|console)\b</string>
 					<key>name</key>
 					<string>support.type.object.node.js</string>
 				</dict>


### PR DESCRIPTION
Good set of [reference links](http://stackoverflow.com/a/27490981/1742381) on the spec change. But since `module` is still a node construct, I added it to `support.type.object.node.js`