### PR TITLE
Comments after function params in literal methods

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -199,7 +199,7 @@ repository:
         (?x)
           \b(?:(static)\s+)?
           ([_$a-zA-Z][_$\w]*)\s*
-          (?=\([^())]*\)\s*\{)
+          (?=\([^())]*\)(?:\s|/\*.*\*/)*\{)
       beginCaptures:
         '1': {name: storage.type.js}
         '2': {name: entity.name.method.js}
@@ -214,7 +214,7 @@ repository:
           \b(?:(static)\s+)?
           (get|set)\s+
           ([_$a-zA-Z][_$\w]*)\s*
-          (?=\([^())]*\)\s*\{)
+          (?=\([^())]*\)(?:\s|/\*.*\*/)*\{)
       beginCaptures:
         '1': {name: storage.type.js}
         '2': {name: storage.type.accessor.js}

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1429,7 +1429,7 @@
 					<string>(?x)
   \b(?:(static)\s+)?
   ([_$a-zA-Z][_$\w]*)\s*
-  (?=\([^())]*\)\s*\{)</string>
+  (?=\([^())]*\)(?:\s|/\*.*\*/)*\{)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1461,7 +1461,7 @@
   \b(?:(static)\s+)?
   (get|set)\s+
   ([_$a-zA-Z][_$\w]*)\s*
-  (?=\([^())]*\)\s*\{)</string>
+  (?=\([^())]*\)(?:\s|/\*.*\*/)*\{)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Fixes https://github.com/Benvie/JavaScriptNext.tmLanguage/pull/60#issuecomment-72792449. Concise methods with comments between the function parameters and the open `{`, didn't get matched as such. 

Before:
![broken](https://cloud.githubusercontent.com/assets/830952/6082134/d33241ce-adec-11e4-8514-554fcff7b60b.png)

After:
![fixed](https://cloud.githubusercontent.com/assets/830952/6082140/d88bba88-adec-11e4-9916-4fb78cff173c.png)

But more importantly, the methods show up under symbols.