### PR TITLE
Add support for async and generator literal methods

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -206,12 +206,14 @@ repository:
     - name: meta.method.js
       begin: >-
         (?x)
-          \b(?:(static)\s+)?
-          ([_$a-zA-Z][$\w]*)\s*
+          (?:\b(static)\s+)?
+          (?:\b(async)\s+)?
+          (\*?\s*[_$a-zA-Z][$\w]*)\s*
           (?=\([^())]*\)(?:\s|/\*.*\*/)*\{)
       beginCaptures:
         '1': {name: storage.type.js}
-        '2': {name: entity.name.method.js}
+        '2': {name: storage.type.js}
+        '3': {name: entity.name.method.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -254,11 +256,13 @@ repository:
     - name: meta.function.js
       begin: >-
         (?x)
-          \b(function(?:\s*\*|(?=\s|[(])))
+          \b(async)?
+          \s*(function(?:\s*\*|(?=\s|[(])))
           \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
-        '1': {name: storage.type.function.js}
-        '2': {name: entity.name.function.js}
+        '1': {name: storage.type.js}
+        '2': {name: storage.type.function.js}
+        '3': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -271,12 +275,14 @@ repository:
           \.(prototype)
           \.([_$a-zA-Z][$\w]*)
           \s*=
+          \s*(async)?
           \s*(function(?:\s*\*|(?=\s|[(])))\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
         '2': {name: variable.language.prototype.js}
         '3': {name: entity.name.function.js}
-        '4': {name: storage.type.function.js}
+        '4': {name: storage.type.js}
+        '5': {name: storage.type.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -288,11 +294,13 @@ repository:
           (\b_?[A-Z][$\w]*)?
           \.([_$a-zA-Z][$\w]*)
           \s*=
+          \s*(async)?
           \s*(function(?:\s*\*|(?=\s|[(])))\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
         '2': {name: entity.name.function.js}
-        '3': {name: storage.type.function.js}
+        '3': {name: storage.type.js}
+        '4': {name: storage.type.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -303,11 +311,13 @@ repository:
         (?x)
           \b([_$a-zA-Z][$\w]*)
           \s*(:)
+          \s*(async)?
           \s*(function(?:\s*\*|(?=\s|[(])))\s*
       beginCaptures:
         '1': {name: entity.name.function.js}
         '2': {name: punctuation.separator.key-value.js}
-        '3': {name: storage.type.function.js}
+        '3': {name: storage.type.js}
+        '4': {name: storage.type.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -321,6 +331,7 @@ repository:
             ((")((?:[^"]|\\")*)("))
           )\s*
           (:)\s*
+          (async)?\s*
           \b(function(?:\s*\*|(?=\s|[(])))\s*
       beginCaptures:
         '1': {name: string.quoted.single.js}
@@ -332,7 +343,8 @@ repository:
         '7': {name: entity.name.function.js}
         '8': {name: punctuation.definition.string.end.js}
         '9': {name: punctuation.separator.key-value.js}
-        '10': {name: storage.type.function.js}
+        '10': {name: storage.type.js}
+        '11': {name: storage.type.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -358,11 +370,13 @@ repository:
           \.(prototype)
           \.([_$a-zA-Z][$\w]*)
           \s*=
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
         '2': {name: variable.language.prototype.js}
         '3': {name: entity.name.function.js}
+        '4': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}
@@ -376,10 +390,12 @@ repository:
           (\b_?[A-Z][$\w]*)?
           \.([_$a-zA-Z][$\w]*)
           \s*=
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
         '2': {name: entity.name.function.js}
+        '3': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}
@@ -392,10 +408,12 @@ repository:
         (?x)
           \b([_$a-zA-Z][$\w]*)
           \s*(:)
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.function.js}
         '2': {name: punctuation.separator.key-value.js}
+        '3': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}
@@ -411,6 +429,7 @@ repository:
             ((")((?:[^"]|\\")*)("))
           )\s*
           (:)\s*
+          (async)?\s*
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: string.quoted.single.js}
@@ -422,6 +441,7 @@ repository:
         '7': {name: entity.name.function.js}
         '8': {name: punctuation.definition.string.end.js}
         '9': {name: punctuation.separator.key-value.js}
+        '10': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -552,6 +552,7 @@
   \.(prototype)
   \.([_$a-zA-Z][$\w]*)
   \s*=
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -569,6 +570,11 @@
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.js</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -597,6 +603,7 @@
   (\b_?[A-Z][$\w]*)?
   \.([_$a-zA-Z][$\w]*)
   \s*=
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -609,6 +616,11 @@
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -636,6 +648,7 @@
 					<string>(?x)
   \b([_$a-zA-Z][$\w]*)
   \s*(:)
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -648,6 +661,11 @@
 						<dict>
 							<key>name</key>
 							<string>punctuation.separator.key-value.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -678,6 +696,7 @@
     ((")((?:[^"]|\\")*)("))
   )\s*
   (:)\s*
+  (async)?\s*
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -685,6 +704,11 @@
 						<dict>
 							<key>name</key>
 							<string>string.quoted.single.js</string>
+						</dict>
+						<key>10</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -899,16 +923,22 @@
 				<dict>
 					<key>begin</key>
 					<string>(?x)
-  \b(function(?:\s*\*|(?=\s|[(])))
+  \b(async)?
+  \s*(function(?:\s*\*|(?=\s|[(])))
   \s*([_$a-zA-Z][$\w]*)?\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>storage.type.function.js</string>
+							<string>storage.type.js</string>
 						</dict>
 						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.js</string>
+						</dict>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.js</string>
@@ -933,6 +963,7 @@
   \.(prototype)
   \.([_$a-zA-Z][$\w]*)
   \s*=
+  \s*(async)?
   \s*(function(?:\s*\*|(?=\s|[(])))\s*</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -952,6 +983,11 @@
 							<string>entity.name.function.js</string>
 						</dict>
 						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>storage.type.function.js</string>
@@ -975,6 +1011,7 @@
   (\b_?[A-Z][$\w]*)?
   \.([_$a-zA-Z][$\w]*)
   \s*=
+  \s*(async)?
   \s*(function(?:\s*\*|(?=\s|[(])))\s*</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -989,6 +1026,11 @@
 							<string>entity.name.function.js</string>
 						</dict>
 						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>storage.type.function.js</string>
@@ -1011,6 +1053,7 @@
 					<string>(?x)
   \b([_$a-zA-Z][$\w]*)
   \s*(:)
+  \s*(async)?
   \s*(function(?:\s*\*|(?=\s|[(])))\s*</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -1025,6 +1068,11 @@
 							<string>punctuation.separator.key-value.js</string>
 						</dict>
 						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>storage.type.function.js</string>
@@ -1050,6 +1098,7 @@
     ((")((?:[^"]|\\")*)("))
   )\s*
   (:)\s*
+  (async)?\s*
   \b(function(?:\s*\*|(?=\s|[(])))\s*</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -1059,6 +1108,11 @@
 							<string>string.quoted.single.js</string>
 						</dict>
 						<key>10</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>11</key>
 						<dict>
 							<key>name</key>
 							<string>storage.type.function.js</string>
@@ -1462,8 +1516,9 @@
 				<dict>
 					<key>begin</key>
 					<string>(?x)
-  \b(?:(static)\s+)?
-  ([_$a-zA-Z][$\w]*)\s*
+  (?:\b(static)\s+)?
+  (?:\b(async)\s+)?
+  (\*?\s*[_$a-zA-Z][$\w]*)\s*
   (?=\([^())]*\)(?:\s|/\*.*\*/)*\{)</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -1473,6 +1528,11 @@
 							<string>storage.type.js</string>
 						</dict>
 						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.method.js</string>


### PR DESCRIPTION
**Before:**
![before](https://cloud.githubusercontent.com/assets/830952/6426848/8fc71292-bf3b-11e4-9b3f-e7c63624cbbf.png)
**After:**
![after](https://cloud.githubusercontent.com/assets/830952/6426850/910b8f20-bf3b-11e4-94e8-02a1bdd88b7e.png)

@simonzack I can't seem to figure out why generator methods won't match in `brackets -> literal-method`, but will for `literal-class -> literal-method`