### PR TITLE
Allow no spaces b/t async and arrow function

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -356,8 +356,10 @@ repository:
     - name: meta.function.arrow.js
       begin: >-
         (?x)
-          (?:\b(async)\s+)?
+          (?:\b(async)\s*)?
           (?=\([^()]*\)\s*(=>))
+      beginCaptures:
+        '1': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}
@@ -372,7 +374,7 @@ repository:
           \.(prototype)
           \.([_$a-zA-Z][$\w]*)
           \s*=
-          \s*(?:(async)\s+)?
+          \s*(?:(async))?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
@@ -392,7 +394,7 @@ repository:
           (\b_?[A-Z][$\w]*)?
           \.([_$a-zA-Z][$\w]*)
           \s*=
-          \s*(?:(async)\s+)?
+          \s*(?:(async))?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
@@ -410,7 +412,7 @@ repository:
         (?x)
           \b([_$a-zA-Z][$\w]*)
           \s*(:)
-          \s*(?:(async)\s+)?
+          \s*(?:(async))?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.function.js}
@@ -431,7 +433,7 @@ repository:
             ((")((?:[^"]|\\")*)("))
           )
           \s*(:)
-          \s*(?:(async)\s+)?
+          \s*(?:(async))?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: string.quoted.single.js}

--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -356,7 +356,7 @@ repository:
     - name: meta.function.arrow.js
       begin: >-
         (?x)
-          (?:\b(async)\s*)?
+          (\basync)?\s*
           (?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: storage.type.js}
@@ -374,7 +374,7 @@ repository:
           \.(prototype)
           \.([_$a-zA-Z][$\w]*)
           \s*=
-          \s*(?:(async))?
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
@@ -394,7 +394,7 @@ repository:
           (\b_?[A-Z][$\w]*)?
           \.([_$a-zA-Z][$\w]*)
           \s*=
-          \s*(?:(async))?
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
@@ -412,7 +412,7 @@ repository:
         (?x)
           \b([_$a-zA-Z][$\w]*)
           \s*(:)
-          \s*(?:(async))?
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.function.js}
@@ -433,7 +433,7 @@ repository:
             ((")((?:[^"]|\\")*)("))
           )
           \s*(:)
-          \s*(?:(async))?
+          \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: string.quoted.single.js}

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -528,8 +528,16 @@
 				<dict>
 					<key>begin</key>
 					<string>(?x)
-  (?:\b(async)\s+)?
+  (?:\b(async)\s*)?
   (?=\([^()]*\)\s*(=&gt;))</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+					</dict>
 					<key>end</key>
 					<string>(?&lt;=\))\s*(=&gt;)</string>
 					<key>endCaptures</key>
@@ -557,7 +565,7 @@
   \.(prototype)
   \.([_$a-zA-Z][$\w]*)
   \s*=
-  \s*(?:(async)\s+)?
+  \s*(?:(async))?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -608,7 +616,7 @@
   (\b_?[A-Z][$\w]*)?
   \.([_$a-zA-Z][$\w]*)
   \s*=
-  \s*(?:(async)\s+)?
+  \s*(?:(async))?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -653,7 +661,7 @@
 					<string>(?x)
   \b([_$a-zA-Z][$\w]*)
   \s*(:)
-  \s*(?:(async)\s+)?
+  \s*(?:(async))?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -701,7 +709,7 @@
     ((")((?:[^"]|\\")*)("))
   )
   \s*(:)
-  \s*(?:(async)\s+)?
+  \s*(?:(async))?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -528,7 +528,7 @@
 				<dict>
 					<key>begin</key>
 					<string>(?x)
-  (?:\b(async)\s*)?
+  (\basync)?\s*
   (?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -565,7 +565,7 @@
   \.(prototype)
   \.([_$a-zA-Z][$\w]*)
   \s*=
-  \s*(?:(async))?
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -616,7 +616,7 @@
   (\b_?[A-Z][$\w]*)?
   \.([_$a-zA-Z][$\w]*)
   \s*=
-  \s*(?:(async))?
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -661,7 +661,7 @@
 					<string>(?x)
   \b([_$a-zA-Z][$\w]*)
   \s*(:)
-  \s*(?:(async))?
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -709,7 +709,7 @@
     ((")((?:[^"]|\\")*)("))
   )
   \s*(:)
-  \s*(?:(async))?
+  \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
 					<key>beginCaptures</key>
 					<dict>


### PR DESCRIPTION
Regular functions do need a space between `async` and `function`, but arrow functions don't. (Follow up to  https://github.com/Benvie/JavaScriptNext.tmLanguage/commit/b5531fde278eb6818c24f4ee41a452a51aabaef9)

cc: @simonzack 