### PR TITLE
Consistently match "entity.name.function.js"

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -279,7 +279,8 @@ repository:
           \.([_$a-zA-Z][$\w]*)
           \s*=
           \s*(?:(async)\s+)?
-          \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*
+          \s*(function)(?:\s*(\*)|(?=\s|[(]))
+          \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
         '2': {name: variable.language.prototype.js}
@@ -287,6 +288,7 @@ repository:
         '4': {name: storage.type.js}
         '5': {name: storage.type.function.js}
         '6': {name: keyword.generator.asterisk.js}
+        '7': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -299,13 +301,15 @@ repository:
           \.([_$a-zA-Z][$\w]*)
           \s*=
           \s*(?:(async)\s+)?
-          \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*
+          \s*(function)(?:\s*(\*)|(?=\s|[(]))
+          \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
         '2': {name: entity.name.function.js}
         '3': {name: storage.type.js}
         '4': {name: storage.type.function.js}
         '5': {name: keyword.generator.asterisk.js}
+        '6': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -317,13 +321,15 @@ repository:
           \b([_$a-zA-Z][$\w]*)
           \s*(:)
           \s*(?:(async)\s+)?
-          \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*
+          \s*(function)(?:\s*(\*)|(?=\s|[(]))
+          \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
         '1': {name: entity.name.function.js}
         '2': {name: punctuation.separator.key-value.js}
         '3': {name: storage.type.js}
         '4': {name: storage.type.function.js}
         '5': {name: keyword.generator.asterisk.js}
+        '6': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -338,7 +344,8 @@ repository:
           )
           \s*(:)
           \s*(?:(async)\s+)?
-          \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*
+          \s*(function)(?:\s*(\*)|(?=\s|[(]))
+          \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
         '1': {name: string.quoted.single.js}
         '2': {name: punctuation.definition.string.begin.js}
@@ -352,6 +359,7 @@ repository:
         '10': {name: storage.type.js}
         '11': {name: storage.type.function.js}
         '12': {name: keyword.generator.asterisk.js}
+        '13': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -982,7 +982,8 @@
   \.([_$a-zA-Z][$\w]*)
   \s*=
   \s*(?:(async)\s+)?
-  \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*</string>
+  \s*(function)(?:\s*(\*)|(?=\s|[(]))
+  \s*([_$a-zA-Z][$\w]*)?\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1015,6 +1016,11 @@
 							<key>name</key>
 							<string>keyword.generator.asterisk.js</string>
 						</dict>
+						<key>7</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
 					</dict>
 					<key>end</key>
 					<string>(?&lt;=\))</string>
@@ -1035,7 +1041,8 @@
   \.([_$a-zA-Z][$\w]*)
   \s*=
   \s*(?:(async)\s+)?
-  \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*</string>
+  \s*(function)(?:\s*(\*)|(?=\s|[(]))
+  \s*([_$a-zA-Z][$\w]*)?\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1063,6 +1070,11 @@
 							<key>name</key>
 							<string>keyword.generator.asterisk.js</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
 					</dict>
 					<key>end</key>
 					<string>(?&lt;=\))</string>
@@ -1082,7 +1094,8 @@
   \b([_$a-zA-Z][$\w]*)
   \s*(:)
   \s*(?:(async)\s+)?
-  \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*</string>
+  \s*(function)(?:\s*(\*)|(?=\s|[(]))
+  \s*([_$a-zA-Z][$\w]*)?\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1110,6 +1123,11 @@
 							<key>name</key>
 							<string>keyword.generator.asterisk.js</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
 					</dict>
 					<key>end</key>
 					<string>(?&lt;=\))</string>
@@ -1132,7 +1150,8 @@
   )
   \s*(:)
   \s*(?:(async)\s+)?
-  \s*(function)(?:\s*(\*)|(?=\s|[(]))\s*</string>
+  \s*(function)(?:\s*(\*)|(?=\s|[(]))
+  \s*([_$a-zA-Z][$\w]*)?\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1154,6 +1173,11 @@
 						<dict>
 							<key>name</key>
 							<string>keyword.generator.asterisk.js</string>
+						</dict>
+						<key>13</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
 						</dict>
 						<key>2</key>
 						<dict>


### PR DESCRIPTION
In `literal-function-storage`, `meta.function.js` matched the function name as `entity.name.function.js`, while `meta.prototype.function.js`, `meta.function.static.js`, `meta.function.json.js`, and string keyed `meta.function.json.js` matched the name on the object key, but not the function itself. This brings all the patterns in `literal-function-storage` in sync when it comes to matching the function name.

**before**
![before](https://cloud.githubusercontent.com/assets/830952/6430816/019ba98e-bfe9-11e4-8da4-de93d1c13c50.png)

**after**
![after](https://cloud.githubusercontent.com/assets/830952/6430817/02ccbcee-bfe9-11e4-88e7-b52cc6145723.png)