### PR TITLE
More node support

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -16,7 +16,6 @@ repository:
     - include: '#literal-arrow-function-labels'
     - include: '#literal-labels'
 
-    - include: '#support'
     - include: '#literal-keywords'
     - include: '#literal-for'
     - include: '#literal-switch'
@@ -26,6 +25,7 @@ repository:
 
   expression:
     patterns:
+    - include: '#support'
     - include: '#literal-function-storage'
     - include: '#literal-arrow-function-storage'
     - include: '#literal-prototype-storage'   # after literal-function-storage, which includes some prototype strings
@@ -941,17 +941,36 @@ repository:
           )\b
 
     # console
-    - match: (?<!\.)\b(console)(?:\.(warn|info|log|error|time|timeEnd|assert))?\b
+    - match: (?<!\.)\b(console)(?:(\.)(warn|info|log|error|time|timeEnd|assert))?\b
       captures:
         '1': {name: support.type.object.console.js}
-        '2': {name: support.function.console.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: support.function.console.js}
 
     # node
     - name: support.module.node.js
       match: (?<!\.)\b(natives|buffer|child_process|cluster|crypto|dgram|dns|fs|http|https|net|os|path|punycode|string|string_decoder|readline|repl|tls|tty|util|vm|zlib)\b
 
+    - match: (?<!\.)\b(process)(?:(\.)(stdout|stderr|stdin|argv|execPath|execArgv|env|exitCode|version|versions|config|pid|title|arch|platform|mainModule))?\b
+      captures:
+        '1': {name: support.type.object.process.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: support.type.object.process.js}
+
+    - match: (?<!\.)\b(process)(?:(\.)(abort|chdir|cwd|exit|getgid|setgid|getuid|setuid|setgroups|getgroups|initgroups|kill|memoryUsage|nextTick|umask|uptime|hrtime))?\b
+      captures:
+        '1': {name: support.type.object.process.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: support.function.process.js}
+
+    - match: (?<!\.)\b(exports|module(?:(\.)(exports|id|filename|loaded|parent|children)))?\b
+      captures:
+        '1': {name: support.type.object.module.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: support.type.object.module.js}
+
     - name: support.type.object.node.js
-      match: (?<!\.)\b(process\.(env|stdout|stdin|stderr)|process|global|GLOBAL|root|(module\.exports)|module|exports|__dirname|__filename|console)\b
+      match: (?<!\.)\b(global|GLOBAL|root|__dirname|__filename)\b
 
     - name: support.class.node.js
       match: \b(Buffer|EventEmitter|Server|Pipe|Socket|REPLServer|ReadStream|WriteStream|Stream|Inflate|Deflate|InflateRaw|DeflateRaw|GZip|GUnzip|Unzip|Zip)\b

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -143,10 +143,6 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#support</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#literal-keywords</string>
 				</dict>
 				<dict>
@@ -208,6 +204,10 @@
 		<dict>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#support</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#literal-function-storage</string>
@@ -2372,11 +2372,16 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>support.function.console.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(console)(?:\.(warn|info|log|error|time|timeEnd|assert))?\b</string>
+					<string>(?&lt;!\.)\b(console)(?:(\.)(warn|info|log|error|time|timeEnd|assert))?\b</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -2385,8 +2390,74 @@
 					<string>support.module.node.js</string>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.object.process.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.object.process.js</string>
+						</dict>
+					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(process\.(env|stdout|stdin|stderr)|process|global|GLOBAL|root|(module\.exports)|module|exports|__dirname|__filename|console)\b</string>
+					<string>(?&lt;!\.)\b(process)(?:(\.)(stdout|stderr|stdin|argv|execPath|execArgv|env|exitCode|version|versions|config|pid|title|arch|platform|mainModule))?\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.object.process.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.process.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?&lt;!\.)\b(process)(?:(\.)(abort|chdir|cwd|exit|getgid|setgid|getuid|setuid|setgroups|getgroups|initgroups|kill|memoryUsage|nextTick|umask|uptime|hrtime))?\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.object.module.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>support.type.object.module.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?&lt;!\.)\b(exports|module(?:(\.)(exports|id|filename|loaded|parent|children)))?\b</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;!\.)\b(global|GLOBAL|root|__dirname|__filename)\b</string>
 					<key>name</key>
 					<string>support.type.object.node.js</string>
 				</dict>


### PR DESCRIPTION
Does a couple of things:

1. Move `#support` into `#expression` so things like `process` can match inside braces (like for `if (process.env.NODE_ENV === 'production') {}`). Thought maybe the `#brackets` group should also include `#support` on top of `#expression`, but since all the stuff in `#support` are expressions, this made sense (the exception is `debugger`).

1. Do captures for `process` and `module` since now `keyword.operator.accessor.js` is a thing. And fill out the missing properties/methods. For the `process` values, I captured them as `support.type.object.process.js` but maybe a `support.type.value.process.js` makes more sense - I don't know if that's a thing.

1. Removed `console` from `support.type.object.node.js` since it's already in `support.type.object.console.js`. Also added `keyword.operator.accessor.js` for `console`.