### PR TITLE
Capture missing "keyword.operator.accessor"

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -249,17 +249,19 @@ repository:
     patterns:
     # e.g. Sound.prototype
     - name: meta.prototype.access.js
-      match: ([_$a-zA-Z][$\w]*)\.(prototype)\b
+      match: ([_$a-zA-Z][$\w]*)(\.)(prototype)\b
       captures:
         '1': {name: entity.name.class.js}
-        '2': {name: variable.language.prototype.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: variable.language.prototype.js}
 
     # e.g. Sound.prototype = {  } when extending an object
     - name: meta.prototype.declaration.js
-      match: ([_$a-zA-Z][$\w]*)\.(prototype)\s*=\s*
+      match: ([_$a-zA-Z][$\w]*)(\.)(prototype)\s*=\s*
       captures:
         '1': {name: entity.name.class.js}
-        '2': {name: variable.language.prototype.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: variable.language.prototype.js}
 
   literal-function:
     patterns:
@@ -284,20 +286,22 @@ repository:
       begin: >-
         (?x)
           (\b_?[A-Z][$\w]*)?
-          \.(prototype)
-          \.([_$a-zA-Z][$\w]*)
+          (\.)(prototype)
+          (\.)([_$a-zA-Z][$\w]*)
           \s*=
           \s*(?:(async)\s+)?
           \s*(function)(?:\s*(\*)|(?=\s|[(]))
           \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
-        '2': {name: variable.language.prototype.js}
-        '3': {name: entity.name.function.js}
-        '4': {name: storage.type.js}
-        '5': {name: storage.type.function.js}
-        '6': {name: keyword.generator.asterisk.js}
-        '7': {name: entity.name.function.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: variable.language.prototype.js}
+        '4': {name: keyword.operator.accessor.js}
+        '5': {name: entity.name.function.js}
+        '6': {name: storage.type.js}
+        '7': {name: storage.type.function.js}
+        '8': {name: keyword.generator.asterisk.js}
+        '9': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -307,18 +311,19 @@ repository:
       begin: >-
         (?x)
           (\b_?[A-Z][$\w]*)?
-          \.([_$a-zA-Z][$\w]*)
+          (\.)([_$a-zA-Z][$\w]*)
           \s*=
           \s*(?:(async)\s+)?
           \s*(function)(?:\s*(\*)|(?=\s|[(]))
           \s*([_$a-zA-Z][$\w]*)?\s*
       beginCaptures:
         '1': {name: entity.name.class.js}
-        '2': {name: entity.name.function.js}
-        '3': {name: storage.type.js}
-        '4': {name: storage.type.function.js}
-        '5': {name: keyword.generator.asterisk.js}
-        '6': {name: entity.name.function.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: entity.name.function.js}
+        '4': {name: storage.type.js}
+        '5': {name: storage.type.function.js}
+        '6': {name: keyword.generator.asterisk.js}
+        '7': {name: entity.name.function.js}
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
@@ -396,16 +401,18 @@ repository:
       begin: >-
         (?x)
           (\b_?[A-Z][$\w]*)?
-          \.(prototype)
-          \.([_$a-zA-Z][$\w]*)
+          (\.)(prototype)
+          (\.)([_$a-zA-Z][$\w]*)
           \s*=
           \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
-        '2': {name: variable.language.prototype.js}
-        '3': {name: entity.name.function.js}
-        '4': {name: storage.type.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: variable.language.prototype.js}
+        '4': {name: keyword.operator.accessor.js}
+        '5': {name: entity.name.function.js}
+        '6': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}
@@ -417,14 +424,15 @@ repository:
       begin: >-
         (?x)
           (\b_?[A-Z][$\w]*)?
-          \.([_$a-zA-Z][$\w]*)
+          (\.)([_$a-zA-Z][$\w]*)
           \s*=
           \s*(async)?
           \s*(?=\([^()]*\)\s*(=>))
       beginCaptures:
         '1': {name: entity.name.class.js}
-        '2': {name: entity.name.function.js}
-        '3': {name: storage.type.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: entity.name.function.js}
+        '4': {name: storage.type.js}
       end: (?<=\))\s*(=>)
       endCaptures:
         '1': {name: storage.type.function.arrow.js}
@@ -504,24 +512,26 @@ repository:
       match: >-
         (?x)
           (?:(?<=\.)|\b)
-          ([A-Z][$\w]*)\s*\.
+          ([A-Z][$\w]*)\s*(\.)
           ([_$a-zA-Z][$\w]*)\s*
           (\(\s*\))
       captures:
         '1': {name: variable.other.class.js}
-        '2': {name: entity.name.function.js}
-        '3': {name: meta.group.braces.round.function.arguments.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: entity.name.function.js}
+        '4': {name: meta.group.braces.round.function.arguments.js}
 
     - name: meta.function-call.static.with-arguments.js
       match: >-
         (?x)
           (?:(?<=\.)|\b)
-          ([A-Z][$\w]*)\s*\.
+          ([A-Z][$\w]*)\s*(\.)
           ([_$a-zA-Z][$\w]*)\s*
           (?=\()
       captures:
         '1': {name: variable.other.class.js}
-        '2': {name: entity.name.function.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: entity.name.function.js}
 
     - name: meta.function-call.method.without-arguments.js
       match: >-
@@ -883,11 +893,12 @@ repository:
     - name: meta.property.class.js
       match: >-
         (?x)
-          \b([A-Z][$\w]*)\s*\.
+          \b([A-Z][$\w]*)\s*(\.)
           ([_$a-zA-Z][$\w]*)
       captures:
         '1': {name: variable.other.class.js}
-        '2': {name: variable.other.property.static.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: variable.other.property.static.js}
 
     # e.g. obj.property
     - name: variable.other.object.js

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -403,8 +403,8 @@
 					<key>begin</key>
 					<string>(?x)
   (\b_?[A-Z][$\w]*)?
-  \.(prototype)
-  \.([_$a-zA-Z][$\w]*)
+  (\.)(prototype)
+  (\.)([_$a-zA-Z][$\w]*)
   \s*=
   \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
@@ -418,14 +418,24 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>variable.language.prototype.js</string>
+							<string>keyword.operator.accessor.js</string>
 						</dict>
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.js</string>
+							<string>variable.language.prototype.js</string>
 						</dict>
 						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>6</key>
 						<dict>
 							<key>name</key>
 							<string>storage.type.js</string>
@@ -455,7 +465,7 @@
 					<key>begin</key>
 					<string>(?x)
   (\b_?[A-Z][$\w]*)?
-  \.([_$a-zA-Z][$\w]*)
+  (\.)([_$a-zA-Z][$\w]*)
   \s*=
   \s*(async)?
   \s*(?=\([^()]*\)\s*(=&gt;))</string>
@@ -469,9 +479,14 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.js</string>
+							<string>keyword.operator.accessor.js</string>
 						</dict>
 						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>storage.type.js</string>
@@ -877,8 +892,8 @@
 					<key>begin</key>
 					<string>(?x)
   (\b_?[A-Z][$\w]*)?
-  \.(prototype)
-  \.([_$a-zA-Z][$\w]*)
+  (\.)(prototype)
+  (\.)([_$a-zA-Z][$\w]*)
   \s*=
   \s*(?:(async)\s+)?
   \s*(function)(?:\s*(\*)|(?=\s|[(]))
@@ -893,7 +908,76 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>variable.language.prototype.js</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>7</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.js</string>
+						</dict>
+						<key>8</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.generator.asterisk.js</string>
+						</dict>
+						<key>9</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?&lt;=\))</string>
+					<key>name</key>
+					<string>meta.prototype.function.js</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#function-declaration-parameters</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?x)
+  (\b_?[A-Z][$\w]*)?
+  (\.)([_$a-zA-Z][$\w]*)
+  \s*=
+  \s*(?:(async)\s+)?
+  \s*(function)(?:\s*(\*)|(?=\s|[(]))
+  \s*([_$a-zA-Z][$\w]*)?\s*</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.class.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
 						</dict>
 						<key>3</key>
 						<dict>
@@ -916,60 +1000,6 @@
 							<string>keyword.generator.asterisk.js</string>
 						</dict>
 						<key>7</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.js</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(?&lt;=\))</string>
-					<key>name</key>
-					<string>meta.prototype.function.js</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#function-declaration-parameters</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(?x)
-  (\b_?[A-Z][$\w]*)?
-  \.([_$a-zA-Z][$\w]*)
-  \s*=
-  \s*(?:(async)\s+)?
-  \s*(function)(?:\s*(\*)|(?=\s|[(]))
-  \s*([_$a-zA-Z][$\w]*)?\s*</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.class.js</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.js</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.js</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.function.js</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.generator.asterisk.js</string>
-						</dict>
-						<key>6</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.js</string>
@@ -1462,9 +1492,14 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.js</string>
+							<string>keyword.operator.accessor.js</string>
 						</dict>
 						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>meta.group.braces.round.function.arguments.js</string>
@@ -1473,7 +1508,7 @@
 					<key>match</key>
 					<string>(?x)
   (?:(?&lt;=\.)|\b)
-  ([A-Z][$\w]*)\s*\.
+  ([A-Z][$\w]*)\s*(\.)
   ([_$a-zA-Z][$\w]*)\s*
   (\(\s*\))</string>
 					<key>name</key>
@@ -1490,13 +1525,18 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>entity.name.function.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
 					<string>(?x)
   (?:(?&lt;=\.)|\b)
-  ([A-Z][$\w]*)\s*\.
+  ([A-Z][$\w]*)\s*(\.)
   ([_$a-zA-Z][$\w]*)\s*
   (?=\()</string>
 					<key>name</key>
@@ -1717,11 +1757,16 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>variable.language.prototype.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>([_$a-zA-Z][$\w]*)\.(prototype)\b</string>
+					<string>([_$a-zA-Z][$\w]*)(\.)(prototype)\b</string>
 					<key>name</key>
 					<string>meta.prototype.access.js</string>
 				</dict>
@@ -1736,11 +1781,16 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>variable.language.prototype.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>([_$a-zA-Z][$\w]*)\.(prototype)\s*=\s*</string>
+					<string>([_$a-zA-Z][$\w]*)(\.)(prototype)\s*=\s*</string>
 					<key>name</key>
 					<string>meta.prototype.declaration.js</string>
 				</dict>
@@ -2084,12 +2134,17 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>variable.other.property.static.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
 					<string>(?x)
-  \b([A-Z][$\w]*)\s*\.
+  \b([A-Z][$\w]*)\s*(\.)
   ([_$a-zA-Z][$\w]*)</string>
 					<key>name</key>
 					<string>meta.property.class.js</string>


### PR DESCRIPTION
Hey @simonzack, I think the only thing left that _maybe_ should be captured as a `keyword.operator.accessor` is in `literal-constructor`. That one is kinda weird because the entire constructor is captured as `entity.name.type.new.js` - I can see that both as a feature or a bug. So I'll leave that one up to you to decide :smile:

**Before**
![before](https://cloud.githubusercontent.com/assets/830952/6653418/ab249ba8-ca68-11e4-9037-d789264aad8c.png)

**After**
![after](https://cloud.githubusercontent.com/assets/830952/6653420/b022fab4-ca68-11e4-9ab5-afe1a80d5afd.png)
