### PR TITLE
Include string-content in literal-quasi

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -810,6 +810,7 @@ repository:
       endCaptures:
         '0': {name: punctuation.definition.quasi.end.js}
       patterns:
+      - include: '#string-content'
       - name: entity.quasi.element.js
         begin: \${
         beginCaptures:

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1849,6 +1849,10 @@
 					<key>patterns</key>
 					<array>
 						<dict>
+							<key>include</key>
+							<string>#string-content</string>
+						</dict>
+						<dict>
 							<key>begin</key>
 							<string>\${</string>
 							<key>beginCaptures</key>


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/830952/7059726/a27bf8d6-de43-11e4-9067-7588f4c72bc7.png)

After:
![after](https://cloud.githubusercontent.com/assets/830952/7059727/a5adb7c4-de43-11e4-952c-18d1c68bc1e9.png)

Mostly so escapes are matched.