### PR TITLE
Match "await" as control.flow and "yield *"

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -702,8 +702,13 @@ repository:
     patterns:
     - include: '#literal-keyword-storage'
 
+    - match: (?<!\.)\b(yield)\s*(\*)?|\b
+      captures:
+        '1': {name: keyword.control.flow.js}
+        '2': {name: keyword.generator.asterisk.js}
+
     - name: keyword.control.flow.js
-      match: (?<!\.)\b(await|return|yield)\b
+      match: (?<!\.)\b(await|return)\b
 
     - name: keyword.control.conditional.js
       match: (?<!\.)\b(if|else)\b

--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -703,7 +703,7 @@ repository:
     - include: '#literal-keyword-storage'
 
     - name: keyword.control.flow.js
-      match: (?<!\.)\b(return|yield)\b
+      match: (?<!\.)\b(await|return|yield)\b
 
     - name: keyword.control.conditional.js
       match: (?<!\.)\b(if|else)\b
@@ -760,7 +760,7 @@ repository:
   literal-operators:
     patterns:
     - name: keyword.operator.js
-      match: (?<!\.)\b(await|delete|in|instanceof|new|of|typeof|void|with)\b
+      match: (?<!\.)\b(delete|in|instanceof|new|of|typeof|void|with)\b
 
     - name: keyword.operator.logical.js
       match: >-

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1472,8 +1472,25 @@
 					<string>#literal-keyword-storage</string>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.flow.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.generator.asterisk.js</string>
+						</dict>
+					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(await|return|yield)\b</string>
+					<string>(?&lt;!\.)\b(yield)\s*(\*)?|\b</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;!\.)\b(await|return)\b</string>
 					<key>name</key>
 					<string>keyword.control.flow.js</string>
 				</dict>

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1473,7 +1473,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(return|yield)\b</string>
+					<string>(?&lt;!\.)\b(await|return|yield)\b</string>
 					<key>name</key>
 					<string>keyword.control.flow.js</string>
 				</dict>
@@ -1880,7 +1880,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(await|delete|in|instanceof|new|of|typeof|void|with)\b</string>
+					<string>(?&lt;!\.)\b(delete|in|instanceof|new|of|typeof|void|with)\b</string>
 					<key>name</key>
 					<string>keyword.operator.js</string>
 				</dict>


### PR DESCRIPTION
1. IMHO, `await` doesn't make sense as in `keyword.operator.js`. It belongs in `keyword.control.flow.js`.
2. `yield *` is a [thing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Example_with_yield*).

cc: @simonzack 