### PR TITLE
Fix regexp "punctuation.definition.string.begin"

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -915,7 +915,7 @@ repository:
     patterns:
     # ignore ++, -- since they're uncommon, distinguishing them is not possible in sublime text, see:
     #   http://stackoverflow.com/questions/5519596/when-parsing-javascript-what-determines-the-meaning-of-a-slash
-    - contentName: string.regexp.js
+    - name: string.regexp.js
       begin: >-
         (?x)
           (?<=
@@ -926,13 +926,11 @@ repository:
           (/)
           (?!/|\*|$)
       beginCaptures:
-        '1': {name: string.regexp.js}
-        '2': {name: punctuation.definition.string.begin.js}
-      end: ((/)([gimy]*))
+        '1': {name: punctuation.definition.string.begin.js}
+      end: (/)([gimy]*)
       endCaptures:
-        '1': {name: string.regexp.js}
-        '2': {name: punctuation.definition.string.end.js}
-        '3': {name: keyword.other.js}
+        '1': {name: punctuation.definition.string.end.js}
+        '2': {name: keyword.other.js}
       patterns:
       - include: source.regexp.js
 

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -2147,36 +2147,26 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>string.regexp.js</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
 							<string>punctuation.definition.string.begin.js</string>
 						</dict>
 					</dict>
-					<key>contentName</key>
-					<string>string.regexp.js</string>
 					<key>end</key>
-					<string>((/)([gimy]*))</string>
+					<string>(/)([gimy]*)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>string.regexp.js</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
 							<string>punctuation.definition.string.end.js</string>
 						</dict>
-						<key>3</key>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.js</string>
 						</dict>
 					</dict>
+					<key>name</key>
+					<string>string.regexp.js</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Before:
```
var regexp = /hello/g;
             ^  ^  ^^- string.regexp.js keyword.other.js 
             |  |  +-- string.regexp.js punctuation.definition.string.end.js
             |  +----- string.regexp.js
             +-------- string.regexp.js
```

After:
```
var regexp = /hello/g;
             ^  ^  ^^- string.regexp.js keyword.other.js 
             |  |  +-- string.regexp.js punctuation.definition.string.end.js
             |  +----- string.regexp.js
             +-------- string.regexp.js punctuation.definition.string.begin.js
```

cc: @simonzack 