### PR TITLE
add support for ES7 class property initializers

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -209,6 +209,8 @@ repository:
         - include: '#brackets'
         - include: '#comments'
         - include: '#literal-method'
+        - include: '#literal-property-initializer'
+        - include: '#expression'
 
   literal-method:
     patterns:
@@ -244,6 +246,14 @@ repository:
       end: (?<=\))
       patterns:
       - include: '#function-declaration-parameters'
+
+  literal-property-initializer:
+    patterns:
+    - name: meta.class.property.js
+      match: \b(?:(static)\s+)?([_$a-zA-Z][$\w]*)\s*=
+      captures:
+        '1': {name: storage.type.js}
+        '2': {name: variable.class.property.js}
 
   literal-prototype:
     patterns:

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -1046,6 +1046,14 @@
 									<key>include</key>
 									<string>#literal-method</string>
 								</dict>
+								<dict>
+									<key>include</key>
+									<string>#literal-property-initializer</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#expression</string>
+								</dict>
 							</array>
 						</dict>
 					</array>
@@ -2118,6 +2126,31 @@
 					<string>\.</string>
 					<key>name</key>
 					<string>keyword.operator.accessor.js</string>
+				</dict>
+			</array>
+		</dict>
+		<key>literal-property-initializer</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.class.property.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(?:(static)\s+)?([_$a-zA-Z][$\w]*)\s*=</string>
+					<key>name</key>
+					<string>meta.class.property.js</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
This PR adds support for [ES7 Class Property Initializers](https://gist.github.com/jeffmo/054df782c05639da2adb) (stage 0 proposal, but supported in Babel and already widely used).

Screenshots using Material Theme color scheme:

#### Before:

<img width="606" alt="screen shot 2015-07-25 at 8 40 28 pm" src="https://cloud.githubusercontent.com/assets/499550/8892012/21b5cd88-330e-11e5-9185-5184e353cb7f.png">

#### After:

<img width="613" alt="screen shot 2015-07-25 at 8 43 33 pm" src="https://cloud.githubusercontent.com/assets/499550/8892013/27c8240a-330e-11e5-83c0-0b6e6b5ae617.png">
