### PR TITLE
Added 'this' to literal-language-constant

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -739,6 +739,9 @@ repository:
 
     - name: constant.language.nan.js
       match: (?<!\.)\bNaN\b
+      
+    - name: constant.language.this.js
+      match: (?<!\.)\bthis\b
 
   literal-constructor:
     patterns:


### PR DESCRIPTION
It seems that 'this' wasn't being highlighted properly so I added it to the literal-language-constant patterns. It looks like it works now.