### PR TITLE
Allow escaped slashes inside regexps.

### DIFF
--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -2340,7 +2340,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(/)([gimy]*)</string>
+					<string>[^\\](/)([gimy]*)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Previously regexps like:

```javascript
/\//
```

Would be incorrectly matched, because the regexp would end on the escaped slash.

It should now handle that case properly.