### PR TITLE
add missing indexed symbols files

### DIFF
--- a/Indexed Symbols.tmPreferences
+++ b/Indexed Symbols.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.js meta.function.js entity.name.function.js, meta.class.js entity.name.class.js, entity.name.method.js, entity.name.accessor.js</string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedSymbolList</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>

--- a/Symbol List Function.tmPreferences
+++ b/Symbol List Function.tmPreferences
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>name</key>


### PR DESCRIPTION
This fixes the Sublime 3 GoTo Definition functionality. 
I've only tested this on OSX Mountain Lion 10.9.5 as it's the only one I have.