### PR TITLE
Removes empty captures

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -841,12 +841,12 @@ repository:
         (?x)
           !(?!=)| # logical-not     right-to-left   right
           &&    | # logical-and     left-to-right   both
-          \|\|  | # logical-or      left-to-right   both
+          \|\|    # logical-or      left-to-right   both
 
     - name: keyword.operator.assignment.js
       match: >-
         (?x)
-          =(?!=)| # assignment      right-to-left   both
+          =(?!=)  # assignment      right-to-left   both
 
     - name: keyword.operator.assignment.augmented.js
       match: >-
@@ -861,7 +861,7 @@ repository:
           \|=  | # assignment      right-to-left   both
           <<=  | # assignment      right-to-left   both
           >>=  | # assignment      right-to-left   both
-          >>>= | # assignment      right-to-left   both
+          >>>=   # assignment      right-to-left   both
 
     - name: keyword.operator.bitwise.js
       match: >-


### PR DESCRIPTION
These rules are causing issues with both `first-mate` and `vscode-textmate`, because they match empty strings and can cause infinite loops. The trailing `|` are unnecessary and are not present in the other rules, so I just had to remove them altogether.