### PR TITLE
Add support for tagged html template strings

### DIFF
--- a/JavaScriptNext.YAML-tmLanguage
+++ b/JavaScriptNext.YAML-tmLanguage
@@ -32,6 +32,7 @@ repository:
 
     - include: '#literal-regexp'              # before operators to avoid ambiguities
     - include: '#literal-number'
+    - include: '#literal-tagged-html'
     - include: '#literal-template-string'
     - include: '#literal-string'
     - include: '#literal-language-constant'
@@ -984,6 +985,19 @@ repository:
           '0': {name: punctuation.template-string.element.end.js}
         patterns:
         - include: '#expression'
+
+  literal-tagged-html:
+    patterns:
+    - contentName: text.html.basic.embedded.js
+      begin: '(html)(`)'
+      beginCaptures:
+        '1': {name: meta.function-call.tagged-template.js}
+        '2': {name: punctuation.definition.string.template.begin.js}
+      end: '`'
+      endCaptures:
+        '0': {name: punctuation.definition.string.template.end.js}
+      patterns:
+      - include: 'text.html.basic'
 
   literal-regexp:
     patterns:

--- a/JavaScriptNext.tmLanguage
+++ b/JavaScriptNext.tmLanguage
@@ -230,6 +230,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#literal-tagged-html</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#literal-template-string</string>
 				</dict>
 				<dict>
@@ -2244,79 +2248,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>literal-template-string</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>([a-zA-Z$_][\w$_]*)?(`)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.template-string.tag.name.js</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.template-string.begin.js</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>`</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.template-string.end.js</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>string.template-string.js</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#string-content</string>
-						</dict>
-						<dict>
-							<key>begin</key>
-							<string>\${</string>
-							<key>beginCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.template-string.element.begin.js</string>
-								</dict>
-							</dict>
-							<key>end</key>
-							<string>}</string>
-							<key>endCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.template-string.element.end.js</string>
-								</dict>
-							</dict>
-							<key>name</key>
-							<string>entity.template-string.element.js</string>
-							<key>patterns</key>
-							<array>
-								<dict>
-									<key>include</key>
-									<string>#expression</string>
-								</dict>
-							</array>
-						</dict>
-					</array>
-				</dict>
-			</array>
-		</dict>
 		<key>literal-regexp</key>
 		<dict>
 			<key>patterns</key>
@@ -2516,6 +2447,121 @@
 								<dict>
 									<key>include</key>
 									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>literal-tagged-html</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(html)(`)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>meta.function-call.tagged-template.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.template.begin.js</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>text.html.basic.embedded.js</string>
+					<key>end</key>
+					<string>`</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.template.end.js</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>text.html.basic</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>literal-template-string</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>([a-zA-Z$_][\w$_]*)?(`)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.template-string.tag.name.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.template-string.begin.js</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>`</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.template-string.end.js</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>string.template-string.js</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#string-content</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\${</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.template-string.element.begin.js</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.template-string.element.end.js</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>entity.template-string.element.js</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#expression</string>
 								</dict>
 							</array>
 						</dict>


### PR DESCRIPTION
A companion PR to https://github.com/babel/babel-sublime/pull/350, since the feature is missing there as well :)

<img width="741" alt="screenshot 2018-02-15 02 58 34" src="https://user-images.githubusercontent.com/145218/36237821-aa003242-11fe-11e8-8715-4561251fbb4f.png">

Adds support for HTML highlighting inside template literals tagged with an `html` function. Support for this feature has been implemented in Babel highlighting for Atom for a while, and even GitHub highlights it like it's supposed to (thanks @DylanPiercey for pointing that out in https://github.com/babel/babel-sublime/issues/138#issuecomment-282814040):

```js
const it = html`
  <div>hi</div>
`
```

It's also a fairly important part of [Polymer](https://www.polymer-project.org/) starting from 2.4. As the Polymer documentation puts it:

> Some text editors support HTML code highlighting in JavaScript template literals tagged with a function called html.
